### PR TITLE
Fix JSON string escaping logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+*.log
+.DS_Store

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -77,11 +77,17 @@ const parseJsonFromText = <T,>(text: string, isArrayExpected: boolean = false): 
       for (let i = 0; i < arrayContent.length; i++) {
         const char = arrayContent[i];
 
-        if (char === '"' && (i === 0 || arrayContent[i-1] !== '\\' || (arrayContent[i-1] === '\\' && i > 1 && arrayContent[i-2] === '\\') ) ) {
-          // Basic string toggle: handle simple escapes like \\" but not complex ones deeply
-           if (i > 0 && arrayContent[i-1] === '\\' && !(i > 1 && arrayContent[i-2] === '\\')) {
-            // It's an escaped quote, don't toggle inString
-          } else {
+        if (char === '"') {
+          let backslashCount = 0;
+          for (let j = i - 1; j >= 0; j--) {
+            if (arrayContent[j] === '\\') {
+              backslashCount++;
+            } else {
+              break;
+            }
+          }
+
+          if (backslashCount % 2 === 0) {
             inString = !inString;
           }
         }


### PR DESCRIPTION
Improved the custom JSON parsing logic in `services/geminiService.ts` to correctly handle escaped quotes and backslashes by counting preceding backslashes. This ensures that sequences like `\\\"` are parsed correctly as an escaped backslash followed by an escaped quote, rather than incorrectly terminating the string. Also added a `.gitignore` file.

---
*PR created automatically by Jules for task [14537066287326325849](https://jules.google.com/task/14537066287326325849) started by @DhaatuTheGamer*